### PR TITLE
adds the operator to the where clauses allowing for single line chaining

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,7 +22,7 @@ class ServiceProvider extends BaseServiceProvider
                     ->whereColumn($where['first'], $where['second']);
             });
         });
-        
+
         QueryBuilder::macro('earliestRelation', function () {
             return $this->relation('min');
         });
@@ -31,23 +31,23 @@ class ServiceProvider extends BaseServiceProvider
             return $this->relation('max');
         });
 
-        QueryBuilder::macro('whereEarliest', function ($column, $value) {
-            return $this->earliestRelation()->where($column, $value);
+        QueryBuilder::macro('whereEarliest', function ($column, $operator = null, $value = null) {
+            return $this->earliestRelation()->where($column, $operator, $value);
         });
 
-        QueryBuilder::macro('whereLatest', function ($column, $value) {
-            return $this->latestRelation()->where($column, $value);
+        QueryBuilder::macro('whereLatest', function ($column, $operator = null, $value = null) {
+            return $this->latestRelation()->where($column, $operator, $value);
         });
 
-        EloquentBuilder::macro('whereEarliestRelation', function ($relation, $column, $value) {
-            return $this->whereHas($relation, function($query) use ($column, $value) {
-                return $query->whereEarliest($column, $value);
+        EloquentBuilder::macro('whereEarliestRelation', function ($relation, $column, $operator = null, $value = null) {
+            return $this->whereHas($relation, function($query) use ($column, $operator, $value) {
+                return $query->whereEarliest($column, $operator, $value);
             });
         });
 
-        EloquentBuilder::macro('whereLatestRelation', function ($relation, $column, $value) {
-            return $this->whereHas($relation, function ($query) use ($column, $value) {
-                $query->whereLatest($column, $value);
+        EloquentBuilder::macro('whereLatestRelation', function ($relation, $column,  $operator = null, $value = null) {
+            return $this->whereHas($relation, function ($query) use ($column, $operator, $value) {
+                $query->whereLatest($column, $operator, $value);
             });
         });
     }

--- a/tests/Unit/EloquentLatestRelationTest.php
+++ b/tests/Unit/EloquentLatestRelationTest.php
@@ -50,7 +50,7 @@ class EloquentLatestRelationTest extends TestCase
                 'device_type' => 'mobile',
                 'country' => null
             ], [
- 
+
                 'user_id' => 2,
                 'created_at' => Carbon::now()->subDays(3),
                 'device_type' => 'mobile',
@@ -109,9 +109,9 @@ class EloquentLatestRelationTest extends TestCase
         $loggedInYesterday = User::whereHas('logins', function ($query) {
             $query->latestRelation()->whereBetween(
                 'created_at', [
-                    Carbon::now()->subDay(1)->startOfDay(),
-                    Carbon::now()->subDay(1)->endOfDay()
-                ]);
+                Carbon::now()->subDay(1)->startOfDay(),
+                Carbon::now()->subDay(1)->endOfDay()
+            ]);
         });
 
         $this->assertSame(1, $loggedInYesterday->count());
@@ -121,7 +121,7 @@ class EloquentLatestRelationTest extends TestCase
     /**
      * @test
      */
-    public function earilest_relation()
+    public function earliest_relation()
     {
         $users = User::whereHas('logins', function ($query) {
             $query->earliestRelation()->whereNotNull('country');
@@ -160,12 +160,12 @@ class EloquentLatestRelationTest extends TestCase
     /**
      * @test
      */
-    public function where_earilest()
+    public function where_earliest()
     {
         $users = User::whereHas('logins', function ($query) {
             $query->whereEarliest('device_type', 'mobile');
         })->get();
-        
+
         $this->assertCount(3, $users);
 
         $users = User::whereHas('logins', function ($query) {
@@ -181,7 +181,7 @@ class EloquentLatestRelationTest extends TestCase
     public function where_latest_relation()
     {
         $users = User::whereLatestRelation('logins', 'device_type', 'mobile')->get();
-        
+
         $this->assertCount(2, $users);
         $this->assertSame('Cameron Frye', $users->first()->name);
         $this->assertSame('mobile', $users->first()->lastLogin->device_type);
@@ -200,15 +200,37 @@ class EloquentLatestRelationTest extends TestCase
     /**
      * @test
      */
-    public function where_earilest_relation()
+    public function where_earliest_relation()
     {
         $users = User::whereEarliestRelation('logins', 'device_type', 'mobile')->get();
-        
+
         $this->assertCount(3, $users);
 
         $users = User::whereEarliestRelation('logins', 'device_type', 'desktop')->get();
 
         $this->assertCount(0, $users);
+    }
+
+    /**
+     * @test
+     */
+    public function where_latest_relation_country_is_not_null()
+    {
+        $users = User::whereLatestRelation('logins', 'country', '!=', 'null');
+
+        $this->assertSame(1, $users->count());
+        $this->assertSame('Ferris Bueller', $users->first()->name);
+    }
+
+    /**
+     * @test
+     */
+    public function where_earliest_relation_country_is_not_null()
+    {
+        $users = User::whereEarliestRelation('logins', 'country', '!=', 'null');
+
+        $this->assertSame(1, $users->count());
+        $this->assertSame('Ed Rooney', $users->first()->name);
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to fetch the latest/earliest relationship in a single line.

```php
// Before
$users = User::whereHas('logins', function ($query) {
    $query->latestRelation()->whereNotNull('country');
});

// After
$users = User::whereLatestRelation('logins', 'country', '!=', 'null');
```